### PR TITLE
[ESC-14] 하단 영역 sticky 적용 (#24)

### DIFF
--- a/src/features/donationCertificate/Container.style.tsx
+++ b/src/features/donationCertificate/Container.style.tsx
@@ -1,19 +1,19 @@
-import colors from "shared/assets/colors";
 import styled from "styled-components";
 
-export const Container = styled.div`
-  position: relative;
-  overflow-x: hidden;
-  overflow-y: scroll;
-  ::-webkit-scrollbar {
-    display: none;
-  }
+import ScrollableContainer from "shared/components/ScrollableContainer/Container";
+
+import colors from "shared/assets/colors";
+
+export const Container = styled(ScrollableContainer)`
+  padding-top: 2rem;
+  background-image: linear-gradient(205deg, #38cc5f, #27e24b);
+`;
+
+export const ContentContainer = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
-  height: 100%;
-  padding: 2rem;
-  background-image: linear-gradient(205deg, #38cc5f, #27e24b);
+  width: 100%;
 `;
 
 export const ShareButton = styled.button`
@@ -90,6 +90,16 @@ export const CorporationLogos = styled.div`
   > img {
     width: 5rem;
   }
+`;
+
+export const ButtonContainer = styled.div`
+  position: sticky;
+  bottom: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 100%;
+  padding: 2.4rem 0rem 2rem 0rem;
 `;
 
 export const ButtonArea = styled.div`

--- a/src/features/donationCertificate/Container.tsx
+++ b/src/features/donationCertificate/Container.tsx
@@ -3,17 +3,19 @@ import useDonationCertificate from "./hooks/useDonationCertificate";
 import Button, { ButtonTheme } from "shared/components/Button/Container";
 
 import {
-  AirplaneImage,
-  BackToMainButton,
-  ButtonArea,
-  CertificateArea,
   Container,
-  CorporationLogos,
-  Description,
-  Phrase,
+  ContentContainer,
   ShareButton,
-  Signature,
   Title,
+  Description,
+  CertificateArea,
+  AirplaneImage,
+  Phrase,
+  CorporationLogos,
+  Signature,
+  ButtonContainer,
+  ButtonArea,
+  BackToMainButton,
 } from "./Container.style";
 import escalPrintSeal from "shared/assets/imgs/escalPrintSeal.png";
 import escalPrintLogo from "shared/assets/imgs/escalPrintLogo.png";
@@ -32,38 +34,42 @@ const DonationCertificateContainer = () => {
 
   return (
     <Container>
-      <ShareButton onClick={handleShareClick}>공유하기</ShareButton>
-      <CertificateArea ref={certificateAreaRef}>
-        <Title>{`${nickname}님!
+      <ContentContainer>
+        <ShareButton onClick={handleShareClick}>공유하기</ShareButton>
+        <CertificateArea ref={certificateAreaRef}>
+          <Title>{`${nickname}님!
         기부에 동참해주셔서 감사해요 :)`}</Title>
-        <Description>{`꿈이 이루어질 수 있도록 에스칼프린트가 함께할게요!
+          <Description>{`꿈이 이루어질 수 있도록 에스칼프린트가 함께할게요!
         저소득층 기부에 함께 동참해주셔서 너무 고마워요!`}</Description>
-        <AirplaneImage src={paperAirplaneGreen} alt="paperAirplaneGreen" />
-        <Phrase>위 자는 저소득층 기부에 동참하였음을 인증합니다.</Phrase>
-        <Signature>
-          <span>에스칼디렉션 대표인</span>
-          <img src={escalPrintSeal} alt="escalPrintSeal" />
-        </Signature>
-        <CorporationLogos>
-          <img src={escalPrintLogo} alt="escalPrintLogo" />
-          <img src={childFundLogo} alt="childFundLogo" />
-        </CorporationLogos>
-      </CertificateArea>
-      <ButtonArea>
-        <Button
-          onButtonClick={handleSaveImageClick}
-          text="이미지 저장"
-          theme={ButtonTheme.LIGHT}
-        />
-        <Button
-          onButtonClick={handleHistoryClick}
-          text="내 꿈 기부내역 보러가기"
-          theme={ButtonTheme.DARK}
-        />
-      </ButtonArea>
-      <BackToMainButton onClick={handleBackToMainClick}>
-        홈으로 이동하기
-      </BackToMainButton>
+          <AirplaneImage src={paperAirplaneGreen} alt="paperAirplaneGreen" />
+          <Phrase>위 자는 저소득층 기부에 동참하였음을 인증합니다.</Phrase>
+          <Signature>
+            <span>에스칼디렉션 대표인</span>
+            <img src={escalPrintSeal} alt="escalPrintSeal" />
+          </Signature>
+          <CorporationLogos>
+            <img src={escalPrintLogo} alt="escalPrintLogo" />
+            <img src={childFundLogo} alt="childFundLogo" />
+          </CorporationLogos>
+        </CertificateArea>
+      </ContentContainer>
+      <ButtonContainer>
+        <ButtonArea>
+          <Button
+            onButtonClick={handleSaveImageClick}
+            text="이미지 저장"
+            theme={ButtonTheme.LIGHT}
+          />
+          <Button
+            onButtonClick={handleHistoryClick}
+            text="내 꿈 기부내역 보러가기"
+            theme={ButtonTheme.DARK}
+          />
+        </ButtonArea>
+        <BackToMainButton onClick={handleBackToMainClick}>
+          홈으로 이동하기
+        </BackToMainButton>
+      </ButtonContainer>
     </Container>
   );
 };

--- a/src/features/donationHistory/Container.tsx
+++ b/src/features/donationHistory/Container.tsx
@@ -15,6 +15,7 @@ import {
   Subtitle,
   SubtitleArea,
 } from "./Container.style";
+import { AnnouncementAreaContainer } from "shared/components/ScrollableContainer/Container.style";
 import dummyData from "./dummyData";
 
 const DonationHistoryContainer = () => {
@@ -47,12 +48,14 @@ const DonationHistoryContainer = () => {
         </DonationList>
         <LoadMoreButton onClick={handleLoadMoreClick}>더보기</LoadMoreButton>
       </ContentContainer>
-      <Announcement
-        buttonText="여기"
-        leftText="각종 공지사항은 "
-        onButtonClick={handleNoticeClick}
-        rightText="에서 확인하실 수 있어요!"
-      />
+      <AnnouncementAreaContainer>
+        <Announcement
+          buttonText="여기"
+          leftText="각종 공지사항은 "
+          onButtonClick={handleNoticeClick}
+          rightText="에서 확인하실 수 있어요!"
+        />
+      </AnnouncementAreaContainer>
     </Container>
   );
 };

--- a/src/features/donationHistory/detail/Container.tsx
+++ b/src/features/donationHistory/detail/Container.tsx
@@ -1,4 +1,3 @@
-import { useEffect } from "react";
 import NavigationBar from "shared/components/NavigationBar/Container";
 import SubtitleBar from "shared/components/SubtitleBar/Container";
 

--- a/src/features/findAccount/Container.style.tsx
+++ b/src/features/findAccount/Container.style.tsx
@@ -2,22 +2,11 @@ import styled from "styled-components";
 
 import Title from "shared/components/Title/Container";
 import Description from "shared/components/Description/Container";
-import Announcement from "shared/components/Announcement/Container";
 
 import colors from "shared/assets/colors";
 
-export const Container = styled.div`
-  position: relative;
-  overflow-x: hidden;
-  overflow-y: scroll;
-  ::-webkit-scrollbar {
-    display: none;
-  }
-  display: flex;
-  flex-direction: column;
-  height: 100%;
-  padding: 2rem;
-  padding-top: 2.5rem;
+export const ContentContainer = styled.div`
+  width: 100%;
 `;
 
 export const StyledTitle = styled(Title)`
@@ -66,11 +55,4 @@ export const TabContentsPaper = styled.div`
   padding: 2.8rem 1.8rem 0rem 1.8rem;
   border-radius: 2rem;
   background-color: ${colors.white};
-`;
-
-export const StyledAnnouncement = styled(Announcement)`
-  position: absolute;
-  left: 50%;
-  bottom: 2rem;
-  transform: translateX(-50%);
 `;

--- a/src/features/findAccount/Container.tsx
+++ b/src/features/findAccount/Container.tsx
@@ -4,56 +4,59 @@ import FindIdTabContents from "features/findAccount/components/FindIdTabContents
 import FindPasswordTabContents from "./components/FindPasswordTabContents";
 
 import {
-  Container,
+  ContentContainer,
   StyledTitle,
   StyledDescription,
   TabArea,
-  StyledAnnouncement,
   TabItem,
   TabContentsPaper,
   TabList,
 } from "./Container.style";
+import ScrollableContainer from "shared/components/ScrollableContainer/Container";
 
 const FindAccountContainer = () => {
   const { handleJoinClick, handleTabClick, selectedTab } = useFindAccount();
 
   return (
-    <Container>
-      <StyledTitle
-        text={`깜-빡 잊었어도 괜찮아요
+    <ScrollableContainer
+      bottomAnnouncement={{
+        buttonText: "회원가입 하러가기",
+        leftText: "처음이라면 ",
+        onButtonClick: handleJoinClick,
+        rightText: "를 클릭해주세요!",
+      }}
+    >
+      <ContentContainer>
+        <StyledTitle
+          text={`깜-빡 잊었어도 괜찮아요
         우리가 찾아줄거니까!`}
-      />
-      <StyledDescription text="빠르게 찾을 수 있게 도와줄게요" />
-      <TabArea>
-        <TabList>
-          <TabItem
-            onClick={() => handleTabClick("Id")}
-            selected={selectedTab === "Id"}
-          >
-            아이디 찾기
-          </TabItem>
-          <TabItem
-            onClick={() => handleTabClick("Password")}
-            selected={selectedTab === "Password"}
-          >
-            비밀번호 찾기
-          </TabItem>
-        </TabList>
-        <TabContentsPaper>
-          {selectedTab === "Id" ? (
-            <FindIdTabContents />
-          ) : (
-            <FindPasswordTabContents />
-          )}
-        </TabContentsPaper>
-      </TabArea>
-      <StyledAnnouncement
-        buttonText="회원가입 하러가기"
-        leftText="처음이라면 "
-        onButtonClick={handleJoinClick}
-        rightText="를 클릭해주세요!"
-      />
-    </Container>
+        />
+        <StyledDescription text="빠르게 찾을 수 있게 도와줄게요" />
+        <TabArea>
+          <TabList>
+            <TabItem
+              onClick={() => handleTabClick("Id")}
+              selected={selectedTab === "Id"}
+            >
+              아이디 찾기
+            </TabItem>
+            <TabItem
+              onClick={() => handleTabClick("Password")}
+              selected={selectedTab === "Password"}
+            >
+              비밀번호 찾기
+            </TabItem>
+          </TabList>
+          <TabContentsPaper>
+            {selectedTab === "Id" ? (
+              <FindIdTabContents />
+            ) : (
+              <FindPasswordTabContents />
+            )}
+          </TabContentsPaper>
+        </TabArea>
+      </ContentContainer>
+    </ScrollableContainer>
   );
 };
 

--- a/src/features/join/Container.style.tsx
+++ b/src/features/join/Container.style.tsx
@@ -2,20 +2,11 @@ import styled from "styled-components";
 
 import Title from "shared/components/Title/Container";
 import Description from "shared/components/Description/Container";
-import Announcement from "shared/components/Announcement/Container";
 
-export const Container = styled.div`
-  position: relative;
-  overflow-x: hidden;
-  overflow-y: scroll;
-  ::-webkit-scrollbar {
-    display: none;
-  }
+export const ContentContainer = styled.div`
   display: flex;
   flex-direction: column;
-  height: 100%;
-  padding: 2rem;
-  padding-top: 2.5rem;
+  width: 100%;
 `;
 
 export const StyledTitle = styled(Title)`
@@ -24,11 +15,4 @@ export const StyledTitle = styled(Title)`
 
 export const StyledDescription = styled(Description)`
   margin-bottom: 3.6rem;
-`;
-
-export const StyledAnnouncement = styled(Announcement)`
-  position: absolute;
-  left: 50%;
-  bottom: 2rem;
-  transform: translateX(-50%);
 `;

--- a/src/features/join/Container.tsx
+++ b/src/features/join/Container.tsx
@@ -1,14 +1,14 @@
 import useJoin from "./hooks/useJoin";
 
+import ScrollableContainer from "shared/components/ScrollableContainer/Container";
 import Button, { ButtonTheme } from "shared/components/Button/Container";
 import InputArea from "shared/components/InputArea/Container";
 import Input from "shared/components/Input/Container";
 
 import {
-  Container,
   StyledTitle,
   StyledDescription,
-  StyledAnnouncement,
+  ContentContainer,
 } from "./Container.style";
 
 const JoinContainer = () => {
@@ -35,63 +35,66 @@ const JoinContainer = () => {
   } = useJoin();
 
   return (
-    <Container>
-      <StyledTitle
-        text={`1분만 시간내어서
+    <ScrollableContainer
+      bottomAnnouncement={{
+        buttonText: "로그인 하러가기",
+        leftText: "이미 가입했다면? ",
+        onButtonClick: handleLoginClick,
+        rightText: "를 클릭해주세요!",
+      }}
+    >
+      <ContentContainer>
+        <StyledTitle
+          text={`1분만 시간내어서
         회원가입을 부탁드려요`}
-      />
-      <StyledDescription text="회원가입 후에 바로 기부참여가 가능해요" />
-      <InputArea>
-        <Input
-          placeholder="닉네임을 하나 만들어볼까요?"
-          // placeholder="한글 혹은 영문으로 만들어주세요"
-          onValueChange={handleNicknameChange}
-          title="닉네임"
-          value={nickname}
-          wrongInput={nicknameWrongInput}
-          warningMessage={nicknameWarningMessage}
         />
-        <Input
-          placeholder="사용할 아이디를 만들어주세요!"
-          onValueChange={handleIdChange}
-          title="아이디"
-          value={id}
-          wrongInput={idWrongInput}
-          warningMessage={idWarningMessage}
-        />
-        <Input
-          placeholder="8자 이상 20자 이하로 영문, 숫자를 조합해야해요!"
-          onValueChange={handlePasswordChange}
-          title="비밀번호"
-          type="password"
-          value={password}
-          wrongInput={passwordWrongInput}
-          warningMessage={passwordWarningMessage}
-        />
-        <Input
-          placeholder="만든 비밀번호를 확인해볼까요?"
-          onValueChange={handleRetypedPasswordChange}
-          title="비밀번호 확인"
-          type="password"
-          value={retypedPassword}
-          wrongInput={retypedPasswordWrongInput}
-          warningMessage={retypePasswordWarningMessage}
-        />
-      </InputArea>
-      {canSubmit && (
-        <Button
-          onButtonClick={handleSubmitClick}
-          text="기부 동참하러 가기"
-          theme={ButtonTheme.DARK}
-        />
-      )}
-      <StyledAnnouncement
-        buttonText="로그인 하러가기"
-        leftText="이미 가입했다면? "
-        onButtonClick={handleLoginClick}
-        rightText="를 클릭해주세요!"
-      />
-    </Container>
+        <StyledDescription text="회원가입 후에 바로 기부참여가 가능해요" />
+        <InputArea>
+          <Input
+            placeholder="닉네임을 하나 만들어볼까요?"
+            // placeholder="한글 혹은 영문으로 만들어주세요"
+            onValueChange={handleNicknameChange}
+            title="닉네임"
+            value={nickname}
+            wrongInput={nicknameWrongInput}
+            warningMessage={nicknameWarningMessage}
+          />
+          <Input
+            placeholder="사용할 아이디를 만들어주세요!"
+            onValueChange={handleIdChange}
+            title="아이디"
+            value={id}
+            wrongInput={idWrongInput}
+            warningMessage={idWarningMessage}
+          />
+          <Input
+            placeholder="8자 이상 20자 이하로 영문, 숫자를 조합해야해요!"
+            onValueChange={handlePasswordChange}
+            title="비밀번호"
+            type="password"
+            value={password}
+            wrongInput={passwordWrongInput}
+            warningMessage={passwordWarningMessage}
+          />
+          <Input
+            placeholder="만든 비밀번호를 확인해볼까요?"
+            onValueChange={handleRetypedPasswordChange}
+            title="비밀번호 확인"
+            type="password"
+            value={retypedPassword}
+            wrongInput={retypedPasswordWrongInput}
+            warningMessage={retypePasswordWarningMessage}
+          />
+        </InputArea>
+        {canSubmit && (
+          <Button
+            onButtonClick={handleSubmitClick}
+            text="기부 동참하러 가기"
+            theme={ButtonTheme.DARK}
+          />
+        )}
+      </ContentContainer>
+    </ScrollableContainer>
   );
 };
 

--- a/src/features/login/Container.style.tsx
+++ b/src/features/login/Container.style.tsx
@@ -4,18 +4,10 @@ import Title from "shared/components/Title/Container";
 import Description from "shared/components/Description/Container";
 import Announcement from "shared/components/Announcement/Container";
 
-export const Container = styled.div`
-  position: relative;
-  overflow-x: hidden;
-  overflow-y: scroll;
-  ::-webkit-scrollbar {
-    display: none;
-  }
+export const ContentContainer = styled.div`
   display: flex;
   flex-direction: column;
-  height: 100%;
-  padding: 2rem;
-  padding-top: 2.5rem;
+  width: 100%;
 `;
 
 export const StyledTitle = styled(Title)`
@@ -29,11 +21,4 @@ export const StyledDescription = styled(Description)`
 export const FindAccountAnnouncement = styled(Announcement)`
   justify-content: center;
   margin-bottom: 2rem;
-`;
-
-export const JoinAnnouncement = styled(Announcement)`
-  position: absolute;
-  left: 50%;
-  bottom: 2rem;
-  transform: translateX(-50%);
 `;

--- a/src/features/login/Container.tsx
+++ b/src/features/login/Container.tsx
@@ -1,15 +1,15 @@
 import useLogin from "./hooks/useLogin";
 
+import ScrollableContainer from "shared/components/ScrollableContainer/Container";
 import Button, { ButtonTheme } from "shared/components/Button/Container";
 import InputArea from "shared/components/InputArea/Container";
 import Input from "shared/components/Input/Container";
 
 import {
-  Container,
+  ContentContainer,
   StyledTitle,
   StyledDescription,
   FindAccountAnnouncement,
-  JoinAnnouncement,
 } from "./Container.style";
 
 const LoginContainer = () => {
@@ -29,51 +29,54 @@ const LoginContainer = () => {
   } = useLogin();
 
   return (
-    <Container>
-      <StyledTitle
-        text={`다시 만나서 반가워요 :)
+    <ScrollableContainer
+      bottomAnnouncement={{
+        buttonText: "회원가입 하러가기",
+        leftText: "처음이라면 ",
+        onButtonClick: handleJoinClick,
+        rightText: "를 클릭해주세요!",
+      }}
+    >
+      <ContentContainer>
+        <StyledTitle
+          text={`다시 만나서 반가워요 :)
         로그인 후에 이용할 수 있어요!`}
-      />
-      <StyledDescription text="로그인하고 내 꿈들을 확인할 수 있어요" />
-      <InputArea>
-        <Input
-          onValueChange={handleIdChange}
-          placeholder="아이디 기억하고 계시죠?"
-          title="아이디"
-          value={id}
-          warningMessage={idWarningMessage}
-          wrongInput={idWrongInput}
         />
-        <Input
-          onValueChange={handlePasswordChange}
-          placeholder="비밀번호 잊진 않았죠?"
-          title="비밀번호"
-          type="password"
-          value={password}
-          warningMessage={passwordWarningMessage}
-          wrongInput={passwordWrongInput}
+        <StyledDescription text="로그인하고 내 꿈들을 확인할 수 있어요" />
+        <InputArea>
+          <Input
+            onValueChange={handleIdChange}
+            placeholder="아이디 기억하고 계시죠?"
+            title="아이디"
+            value={id}
+            warningMessage={idWarningMessage}
+            wrongInput={idWrongInput}
+          />
+          <Input
+            onValueChange={handlePasswordChange}
+            placeholder="비밀번호 잊진 않았죠?"
+            title="비밀번호"
+            type="password"
+            value={password}
+            warningMessage={passwordWarningMessage}
+            wrongInput={passwordWrongInput}
+          />
+        </InputArea>
+        <FindAccountAnnouncement
+          buttonText="여기"
+          leftText="혹시나 아이디/비밀번호를 잊었다면? "
+          onButtonClick={handleFindAccountClick}
+          rightText="를 클릭해주세요!"
         />
-      </InputArea>
-      <FindAccountAnnouncement
-        buttonText="여기"
-        leftText="혹시나 아이디/비밀번호를 잊었다면? "
-        onButtonClick={handleFindAccountClick}
-        rightText="를 클릭해주세요!"
-      />
-      {canSubmit && (
-        <Button
-          onButtonClick={handleSubmitClick}
-          text="로그인하고 내 꿈 확인하기"
-          theme={ButtonTheme.DARK}
-        />
-      )}
-      <JoinAnnouncement
-        buttonText="회원가입 하러가기"
-        leftText="처음이라면 "
-        onButtonClick={handleJoinClick}
-        rightText="를 클릭해주세요!"
-      />
-    </Container>
+        {canSubmit && (
+          <Button
+            onButtonClick={handleSubmitClick}
+            text="로그인하고 내 꿈 확인하기"
+            theme={ButtonTheme.DARK}
+          />
+        )}
+      </ContentContainer>
+    </ScrollableContainer>
   );
 };
 

--- a/src/features/main/Components/CountingSection/Container.style.tsx
+++ b/src/features/main/Components/CountingSection/Container.style.tsx
@@ -1,0 +1,36 @@
+import colors from "shared/assets/colors";
+import styled from "styled-components";
+
+export const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2.4rem;
+  width: 100%;
+  margin-bottom: 2rem;
+  padding-top: 2.6rem;
+  padding-bottom: 0.8rem;
+  background-color: #fcfdfd;
+
+  > div {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+  }
+`;
+
+export const CountTitle = styled.p`
+  margin-bottom: 1rem;
+  color: ${colors.gray800};
+  font-size: 1.2rem;
+
+  > span {
+    color: inherit;
+    font-size: inherit;
+    font-weight: bold;
+  }
+`;
+
+export const EscalPrintLogo = styled.img`
+  width: 5.5rem;
+`;

--- a/src/features/main/Components/CountingSection/Container.tsx
+++ b/src/features/main/Components/CountingSection/Container.tsx
@@ -1,0 +1,42 @@
+import NumberCards from "features/main/Components/NumberCards/Container";
+
+import { Container, CountTitle, EscalPrintLogo } from "./Container.style";
+
+import escalPrintLogo from "shared/assets/imgs/escalPrintLogo.png";
+
+interface CountingAreaContainerProps {
+  numberOfDonations: number;
+  donationAmount: number;
+}
+
+const CountingSectionContainer = (props: CountingAreaContainerProps) => {
+  return (
+    <Container>
+      <div>
+        <CountTitle>
+          {`지금까지 모인 `}
+          <span>종이비행기 개수</span>
+        </CountTitle>
+        <NumberCards
+          minNumberOfDigits={6}
+          number={props.numberOfDonations}
+          upperColor={"#55ad1e"}
+        />
+      </div>
+      <div>
+        <CountTitle>
+          {`지금까지 모인 `}
+          <span>누적 후원금</span>
+        </CountTitle>
+        <NumberCards
+          minNumberOfDigits={7}
+          number={props.donationAmount}
+          upperColor={"#23b000"}
+        />
+      </div>
+      <EscalPrintLogo src={escalPrintLogo} alt="escalPrintLogo" />
+    </Container>
+  );
+};
+
+export default CountingSectionContainer;

--- a/src/features/main/Components/NoticeSection/Container.style.tsx
+++ b/src/features/main/Components/NoticeSection/Container.style.tsx
@@ -1,0 +1,20 @@
+import styled from "styled-components";
+import colors from "shared/assets/colors";
+
+export const Container = styled.ul`
+  width: 100%;
+
+  > li {
+    line-height: 1.8rem;
+
+    > span {
+      font-weight: 600;
+    }
+
+    > button {
+      color: ${colors.green500};
+      font-weight: 600;
+      text-decoration: underline;
+    }
+  }
+`;

--- a/src/features/main/Components/NoticeSection/Container.tsx
+++ b/src/features/main/Components/NoticeSection/Container.tsx
@@ -1,0 +1,31 @@
+import { Container } from "./Container.style";
+
+interface NoticeAreaContainerProps {
+  onNoticeClick: () => void;
+}
+
+const NoticeSectionContainer = (props: NoticeAreaContainerProps) => {
+  return (
+    <Container>
+      <li>
+        1️⃣ 행사기간 동안
+        <span> 1개 계정 당 1회에 한하여 참여 가능</span>해요.
+      </li>
+      <li>
+        💚 누적 후원금은
+        <span> 행사 종료 후 전액 초록우산 어린이재단에 기부</span>돼요.
+      </li>
+      <li>
+        {`👀 후원 기부내역은 `}
+        <button onClick={props.onNoticeClick}>공지사항 확인하기</button>를
+        클릭하여 확인 가능해요.
+      </li>
+      <li>
+        🔐 여러분의 꿈은
+        <span> 구름 속에서 안전하게 보관</span>되니 걱정하지 마세요
+      </li>
+    </Container>
+  );
+};
+
+export default NoticeSectionContainer;

--- a/src/features/main/Components/NumberCards/Container.style.tsx
+++ b/src/features/main/Components/NumberCards/Container.style.tsx
@@ -1,0 +1,26 @@
+import colors from "shared/assets/colors";
+import styled from "styled-components";
+
+export const Container = styled.div`
+  display: flex;
+  gap: 0.2rem;
+  align-items: flex-end;
+`;
+
+export const Card = styled.div<{ upperColor: string }>`
+  min-width: 2rem;
+  padding: 0.5rem;
+  border-radius: 0.4rem;
+  background-image: linear-gradient(
+    ${({ upperColor }) => upperColor} 50%,
+    #94d66c 50%
+  );
+  color: ${colors.white};
+  font-size: 2.2rem;
+  font-weight: bold;
+  text-align: center;
+`;
+
+export const Comma = styled.span`
+  color: #23b000;
+`;

--- a/src/features/main/Components/NumberCards/Container.tsx
+++ b/src/features/main/Components/NumberCards/Container.tsx
@@ -1,0 +1,30 @@
+import useNumberCards from "features/main/hooks/useNumberCards";
+import { Card, Comma, Container } from "./Container.style";
+
+interface NumberCardsProps {
+  minNumberOfDigits: number;
+  number: number;
+  upperColor: string;
+}
+
+// TODO: CountingArea 컴포넌트 디렉토리 안으로 들어가야 할까요?
+const NumberCards = (props: NumberCardsProps) => {
+  const { numberArrayWithComma } = useNumberCards({
+    number: props.number,
+    minNumberOfDigits: props.minNumberOfDigits,
+  });
+
+  return (
+    <Container>
+      {numberArrayWithComma.map((value) =>
+        value === "," ? (
+          <Comma>,</Comma>
+        ) : (
+          <Card upperColor={props.upperColor}>{value}</Card>
+        )
+      )}
+    </Container>
+  );
+};
+
+export default NumberCards;

--- a/src/features/main/Container.style.tsx
+++ b/src/features/main/Container.style.tsx
@@ -3,21 +3,11 @@ import styled from "styled-components";
 import Description from "shared/components/Description/Container";
 import Title from "shared/components/Title/Container";
 
-import colors from "shared/assets/colors";
-
-export const Container = styled.div`
-  position: relative;
-  overflow-x: hidden;
-  overflow-y: scroll;
-  ::-webkit-scrollbar {
-    display: none;
-  }
+export const ContentContainer = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
-  height: 100%;
-  padding: 2rem;
-  padding-top: 2.5rem;
+  width: 100%;
 `;
 
 export const StyledTitle = styled(Title)`
@@ -42,71 +32,4 @@ export const Period = styled.div`
 export const HoldPaperAirplaneImage = styled.img`
   width: 18rem;
   margin-bottom: 3rem;
-`;
-
-export const CountingArea = styled.div`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  width: 100%;
-  margin-bottom: 2rem;
-  padding-top: 2.6rem;
-  padding-bottom: 0.8rem;
-  background-color: #fcfdfd;
-`;
-
-export const CountTitle = styled.p`
-  margin-bottom: 1rem;
-  color: ${colors.gray800};
-  font-size: 1.2rem;
-
-  > span {
-    color: inherit;
-    font-size: inherit;
-    font-weight: bold;
-  }
-`;
-
-export const FlippingArea1 = styled.div`
-  width: 10rem;
-  height: 5rem;
-  margin-bottom: 3rem;
-  background-color: #55ad1e;
-`;
-
-export const FlippingArea2 = styled(FlippingArea1)`
-  margin-bottom: 2.4rem;
-`;
-
-export const EscalPrintLogo = styled.img`
-  width: 5.5rem;
-`;
-
-export const NoticeArea = styled.ul`
-  width: 100%;
-  margin-bottom: 2.4rem;
-
-  > li {
-    line-height: 1.8rem;
-
-    > span {
-      font-weight: 600;
-    }
-
-    > button {
-      color: ${colors.green500};
-      font-weight: 600;
-      text-decoration: underline;
-    }
-  }
-`;
-
-export const ButtonArea = styled.div`
-  display: flex;
-  gap: 0.5rem;
-  width: 100%;
-
-  > button {
-    flex-grow: 1;
-  }
 `;

--- a/src/features/main/Container.tsx
+++ b/src/features/main/Container.tsx
@@ -1,23 +1,17 @@
 import useMain from "./hooks/useMain";
 
-import Button, { ButtonTheme } from "shared/components/Button/Container";
+import ScrollableContainer from "shared/components/ScrollableContainer/Container";
+import CountingSectionContainer from "./Components/CountingSection/Container";
+import NoticeSectionContainer from "./Components/NoticeSection/Container";
 
 import {
-  Container,
+  ContentContainer,
   StyledTitle,
   StyledDescription,
   Period,
   HoldPaperAirplaneImage,
-  CountingArea,
-  CountTitle,
-  FlippingArea1,
-  FlippingArea2,
-  EscalPrintLogo,
-  NoticeArea,
-  ButtonArea,
 } from "./Container.style";
 import holdPaperAirplane from "shared/assets/imgs/holdPaperAirplane.png";
-import escalPrintLogo from "shared/assets/imgs/escalPrintLogo.png";
 
 const MainContainer = () => {
   const {
@@ -30,76 +24,41 @@ const MainContainer = () => {
   } = useMain();
 
   return (
-    <Container>
-      <StyledTitle
-        text={`여러분의 소중한 꿈으로
+    <ScrollableContainer
+      bottomButtons={
+        loginStatus
+          ? {
+              leftButtonText: "내 꿈 기부내역 보기",
+              onLeftButtonClick: handleHistoryClick,
+              rightButtonText: "내 꿈으로 기부하러 가기",
+              onRightButtonClick: handleDonateClick,
+            }
+          : {
+              leftButtonText: "친구랑 함께하기",
+              onLeftButtonClick: handleShareClick,
+              rightButtonText: "회원가입하고 동참하기",
+              onRightButtonClick: handleJoinClick,
+            }
+      }
+    >
+      <ContentContainer>
+        <StyledTitle
+          text={`여러분의 소중한 꿈으로
         따뜻한 기부에 동참하시겠어요?`}
-      />
-      <StyledDescription text="꿈이 적힌 종이비행기 1개당 100원씩 에스칼프린트가 기부해요." />
-      <Period>참여 기간 - 2023.04.10 ~ 2023.04.30</Period>
-      <HoldPaperAirplaneImage src={holdPaperAirplane} alt="holdPaperAirplane" />
-      <CountingArea>
-        <CountTitle>
-          {`지금까지 모인 `}
-          <span>종이비행기 개수</span>
-        </CountTitle>
-        <FlippingArea1></FlippingArea1>
-        <CountTitle>
-          {`지금까지 모인 `}
-          <span>누적 후원금</span>
-        </CountTitle>
-        <FlippingArea2></FlippingArea2>
-        <EscalPrintLogo src={escalPrintLogo} alt="escalPrintLogo" />
-      </CountingArea>
-      <NoticeArea>
-        <li>
-          1️⃣ 행사기간 동안
-          <span> 1개 계정 당 1회에 한하여 참여 가능</span>해요.
-        </li>
-        <li>
-          💚 누적 후원금은
-          <span> 행사 종료 후 전액 초록우산 어린이재단에 기부</span>돼요.
-        </li>
-        <li>
-          {`👀 후원 기부내역은 `}
-          <button onClick={handleNoticeClick}>공지사항 확인하기</button>를
-          클릭하여 확인 가능해요.
-        </li>
-        <li>
-          🔐 여러분의 꿈은
-          <span> 구름 속에서 안전하게 보관</span>되니 걱정하지 마세요
-        </li>
-      </NoticeArea>
-      <ButtonArea>
-        {loginStatus ? (
-          <>
-            <Button
-              onButtonClick={handleHistoryClick}
-              text={"내 꿈 기부내역 보기"}
-              theme={ButtonTheme.LIGHT}
-            />
-            <Button
-              onButtonClick={handleDonateClick}
-              text={"내 꿈으로 기부하러 가기"}
-              theme={ButtonTheme.DARK}
-            />
-          </>
-        ) : (
-          <>
-            <Button
-              onButtonClick={handleShareClick}
-              text={"친구랑 함께하기"}
-              theme={ButtonTheme.LIGHT}
-            />
-            <Button
-              onButtonClick={handleJoinClick}
-              text={"회원가입하고 동참하기"}
-              theme={ButtonTheme.DARK}
-            />
-          </>
-        )}
-      </ButtonArea>
-    </Container>
+        />
+        <StyledDescription text="꿈이 적힌 종이비행기 1개당 100원씩 에스칼프린트가 기부해요." />
+        <Period>참여 기간 - 2023.04.10 ~ 2023.04.30</Period>
+        <HoldPaperAirplaneImage
+          src={holdPaperAirplane}
+          alt="holdPaperAirplane"
+        />
+        <CountingSectionContainer
+          numberOfDonations={12201}
+          donationAmount={122010}
+        />
+        <NoticeSectionContainer onNoticeClick={handleNoticeClick} />
+      </ContentContainer>
+    </ScrollableContainer>
   );
 };
 

--- a/src/features/main/hooks/useNumberCards.ts
+++ b/src/features/main/hooks/useNumberCards.ts
@@ -1,0 +1,32 @@
+interface UseNumberCardsProps {
+  number: number;
+  minNumberOfDigits: number;
+}
+
+const useNumberCards = (props: UseNumberCardsProps) => {
+  let zeroArray: string[] = [];
+
+  const reversedNumberArray = Array.from(String(props.number)).reverse();
+
+  if (props.minNumberOfDigits > reversedNumberArray.length) {
+    const numberOfZero = props.minNumberOfDigits - reversedNumberArray.length;
+    zeroArray = Array.from({ length: numberOfZero }, (_) => "0");
+  }
+
+  const numberArrayWithComma = [...reversedNumberArray, ...zeroArray].reduce(
+    (acc, cur, index) => {
+      if (index > 0 && index % 3 === 0) {
+        return [cur, ",", ...acc];
+      } else {
+        return [cur, ...acc];
+      }
+    },
+    [] as string[]
+  );
+
+  return {
+    numberArrayWithComma,
+  };
+};
+
+export default useNumberCards;

--- a/src/features/selectAirplane/Container.style.tsx
+++ b/src/features/selectAirplane/Container.style.tsx
@@ -5,7 +5,7 @@ import Description from "shared/components/Description/Container";
 
 import colors from "shared/assets/colors";
 
-export const Container = styled.div<{ backgroundColor: string }>`
+export const Container = styled.div`
   position: relative;
   overflow-x: hidden;
   overflow-y: scroll;
@@ -14,7 +14,15 @@ export const Container = styled.div<{ backgroundColor: string }>`
   }
   display: flex;
   flex-direction: column;
+  justify-content: space-between;
   height: 100%;
+  background-color: ${colors.white};
+`;
+
+export const ContentContainer = styled.div<{ backgroundColor: string }>`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
   padding: 2.5rem 2rem 0rem 2rem;
   background-image: ${({ backgroundColor }) => backgroundColor};
 `;
@@ -73,10 +81,22 @@ export const Division = styled.hr`
   border-radius: 0.05rem;
 `;
 
-export const ButtonArea = styled.div`
+export const ButtonContainer = styled.div`
+  position: sticky;
+  /* position: fixed;
+  width: 41.2rem;
+  @media (max-width: 412px) {
+    width: 100%;
+  } */
+  bottom: 0;
   display: flex;
   gap: 0.5rem;
-
+  padding: 2.4rem 2rem 2rem 2rem;
+  background-image: linear-gradient(
+    to bottom,
+    rgba(255, 255, 255, 0) 6%,
+    ${colors.white} 20%
+  );
   > button {
     flex-grow: 1;
   }

--- a/src/features/selectAirplane/Container.tsx
+++ b/src/features/selectAirplane/Container.tsx
@@ -8,8 +8,9 @@ import airplaneList from "./constants/airplaneList";
 import {
   AirplanePreview,
   BoardTitle,
-  ButtonArea,
+  ButtonContainer,
   Container,
+  ContentContainer,
   Division,
   StyledTitle,
   StyledDescription,
@@ -25,36 +26,38 @@ const SelectAirplaneContainer = () => {
   } = useSelectAirplane();
 
   return (
-    <Container backgroundColor={selectedAirplane.containerBackground}>
-      <StyledTitle text="종이비행기를 선택해주세요!" />
-      <StyledDescription text="내가 선택한 종이비행기에 꿈을 적을 수 있어요 :)" />
-      <AirplanePreview borderColor={selectedAirplane.previewBorder}>
-        <img
-          src={selectedAirplane.image}
-          alt={`${selectedAirplane.key} airplane`}
-        />
-      </AirplanePreview>
-      <WhiteBoard>
-        <BoardTitle>종이비행기 고르기</BoardTitle>
-        <Division />
-        <AirplaneSlider
-          list={airplaneList}
-          onAirplaneClick={handleAirplaneClick}
-          selectedAirplaneKey={selectedAirplane.key}
-        />
-        <ButtonArea>
-          <Button
-            onButtonClick={handleMainClick}
-            text="홈으로 이동하기"
-            theme={ButtonTheme.LIGHT}
+    <Container>
+      <ContentContainer backgroundColor={selectedAirplane.containerBackground}>
+        <StyledTitle text="종이비행기를 선택해주세요!" />
+        <StyledDescription text="내가 선택한 종이비행기에 꿈을 적을 수 있어요 :)" />
+        <AirplanePreview borderColor={selectedAirplane.previewBorder}>
+          <img
+            src={selectedAirplane.image}
+            alt={`${selectedAirplane.key} airplane`}
           />
-          <Button
-            onButtonClick={handleWriteClick}
-            text="꿈 작성하기"
-            theme={ButtonTheme.DARK}
+        </AirplanePreview>
+        <WhiteBoard>
+          <BoardTitle>종이비행기 고르기</BoardTitle>
+          <Division />
+          <AirplaneSlider
+            list={airplaneList}
+            onAirplaneClick={handleAirplaneClick}
+            selectedAirplaneKey={selectedAirplane.key}
           />
-        </ButtonArea>
-      </WhiteBoard>
+        </WhiteBoard>
+      </ContentContainer>
+      <ButtonContainer>
+        <Button
+          onButtonClick={handleMainClick}
+          text="홈으로 이동하기"
+          theme={ButtonTheme.LIGHT}
+        />
+        <Button
+          onButtonClick={handleWriteClick}
+          text="꿈 작성하기"
+          theme={ButtonTheme.DARK}
+        />
+      </ButtonContainer>
     </Container>
   );
 };

--- a/src/features/selectAirplane/constants/airplaneList.ts
+++ b/src/features/selectAirplane/constants/airplaneList.ts
@@ -1,7 +1,6 @@
 // TODO: 이건 이 위치에 있는게 맞을지
 import AirplaneKey from "../types/airplaneKey";
 
-import colors from "shared/assets/colors";
 import paperAirplaneGreen from "shared/assets/imgs/paperAirplaneGreen.png";
 import paperAirplaneBeige from "shared/assets/imgs/paperAirplaneBeige.png";
 import paperAirplaneSky from "shared/assets/imgs/paperAirplaneSky.png";
@@ -21,55 +20,49 @@ export interface Airplane {
 const airplaneList: Airplane[] = [
   {
     key: "green",
-    containerBackground: `linear-gradient(
-    to bottom,
-    ${colors.white},
-    ${colors.white} 21%,
-    #64cc7f 65%,
-    #2caf45
-  )`,
+    containerBackground: `linear-gradient(to bottom, #fff 21%, #64cc7f 90%, #2caf45)`,
     previewBorder: `linear-gradient(225deg, #58d78d 99%, #41d359 53%, #62b14f 2%)`,
     image: paperAirplaneGreen,
   },
   {
     key: "beige",
-    containerBackground: `linear-gradient(to bottom, #fff, #fff 21%, #c8cc64 65%, #ccc625)`,
+    containerBackground: `linear-gradient(to bottom, #fff 21%, #c8cc64 90%, #ccc625)`,
     previewBorder: `linear-gradient(225deg, #cbd05d 99%, #e5e054 53%, #ccc625 2%)`,
     image: paperAirplaneBeige,
   },
   {
     key: "sky",
-    containerBackground: `linear-gradient(to bottom, #fff, #fff 21%, #8ddbed 65%, #2bacc9)`,
+    containerBackground: `linear-gradient(to bottom, #fff 21%, #8ddbed 90%, #2bacc9)`,
     previewBorder: `linear-gradient(225deg, #6dd0e6 99%, #62c6dd 53%, #2bacc9 2%)`,
     image: paperAirplaneSky,
   },
   {
     key: "pink",
-    containerBackground: `linear-gradient(to bottom, #fff, #fff 21%, #ffaaf1 65%, #db5dd4)`,
+    containerBackground: `linear-gradient(to bottom, #fff 21%, #ffaaf1 90%, #db5dd4)`,
     previewBorder: `linear-gradient(225deg, #f47ee0 99%, #ff88f8 53%, #db5dd4 2%);`,
     image: paperAirplanePink,
   },
   {
     key: "purple",
-    containerBackground: `linear-gradient(to bottom, #fff, #fff 21%, #d78ded 65%, #802bc9)`,
+    containerBackground: `linear-gradient(to bottom, #fff 21%, #d78ded 90%, #802bc9)`,
     previewBorder: `linear-gradient(225deg, #b467dd 99%, #b762dd 53%, #742bc9 2%)`,
     image: paperAirplanePurple,
   },
   {
     key: "yellowGreen",
-    containerBackground: `linear-gradient(to bottom, #fff, #fff 21%, #a0ffa7 65%, #36e544)`,
+    containerBackground: `linear-gradient(to bottom, #fff 21%, #a0ffa7 90%, #36e544)`,
     previewBorder: `linear-gradient(225deg, #77ef81 99%, #78fa82 53%, #68cb44 2%)`,
     image: paperAirplaneYellowGreen,
   },
   {
     key: "red",
-    containerBackground: `linear-gradient(to bottom, #fff, #fff 21%, #ed8d8d 65%, #c92b2b)`,
+    containerBackground: `linear-gradient(to bottom, #fff 21%, #ed8d8d 90%, #c92b2b)`,
     previewBorder: `linear-gradient(225deg, #e56b6b 99%, #dd6262 53%, #c92b2b 2%)`,
     image: paperAirplaneRed,
   },
   {
     key: "orange",
-    containerBackground: `linear-gradient(to bottom, #fff, #fff 21%, #ffd8aa 65%, #db9c5d)`,
+    containerBackground: `linear-gradient(to bottom, #fff 21%, #ffd8aa 90%, #db9c5d)`,
     previewBorder: `linear-gradient(225deg, #eacc6a 99%, #eabb54 53%, #dbaf5d 2%)`,
     image: paperAirplaneOrange,
   },

--- a/src/features/writeDream/Container.style.tsx
+++ b/src/features/writeDream/Container.style.tsx
@@ -52,6 +52,7 @@ export const WritingText = styled.textarea`
   font-size: 1.8rem;
   font-weight: 600;
   word-break: break-all;
+  line-height: 2.6rem;
 
   ::placeholder {
     color: #c7c7c7;

--- a/src/shared/components/Announcement/Container.style.tsx
+++ b/src/shared/components/Announcement/Container.style.tsx
@@ -3,6 +3,7 @@ import colors from "shared/assets/colors";
 
 export const Container = styled.div`
   display: flex;
+  justify-content: center;
 
   > span {
     display: inline;

--- a/src/shared/components/NavigationBar/Container.tsx
+++ b/src/shared/components/NavigationBar/Container.tsx
@@ -4,6 +4,7 @@ import { BackButton, Container, Title } from "./Container.style";
 import caretLeft from "shared/assets/imgs/caretLeft.png";
 
 interface NavigationBarProps {
+  className?: string;
   title: string;
 }
 
@@ -11,7 +12,7 @@ const NavigationBar = (props: NavigationBarProps) => {
   const { handleGoBackClick } = useNavigationBar();
 
   return (
-    <Container>
+    <Container className={props.className}>
       <BackButton onClick={handleGoBackClick}>
         <img src={caretLeft} alt="caretLeft" />
       </BackButton>

--- a/src/shared/components/ScrollableContainer/Container.style.tsx
+++ b/src/shared/components/ScrollableContainer/Container.style.tsx
@@ -1,0 +1,50 @@
+import styled from "styled-components";
+import colors from "shared/assets/colors";
+
+export const Container = styled.div`
+  position: relative;
+  overflow-x: hidden;
+  overflow-y: scroll;
+  ::-webkit-scrollbar {
+    display: none;
+  }
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  align-items: center;
+  height: 100%;
+  padding: 2.5rem 2rem 0rem 2rem;
+`;
+
+export const ButtonAreaContainer = styled.div`
+  position: sticky;
+  bottom: 0;
+  display: flex;
+  gap: 0.5rem;
+  width: calc(100% + 4rem);
+  padding: 2.4rem 2rem 2rem 2rem;
+  background-image: linear-gradient(
+    to bottom,
+    rgba(255, 255, 255, 0) 6%,
+    ${colors.white} 20%
+  );
+  > button {
+    flex-grow: 1;
+  }
+`;
+
+export const AnnouncementAreaContainer = styled.div`
+  position: sticky;
+  bottom: 0rem;
+  width: calc(100% + 4rem);
+  padding: 2.4rem 0rem 2rem 0rem;
+  background-image: linear-gradient(
+    to bottom,
+    rgba(255, 255, 255, 0) 9.5%,
+    ${colors.white} 25%
+  );
+
+  > div {
+    flex-grow: 1;
+  }
+`;

--- a/src/shared/components/ScrollableContainer/Container.tsx
+++ b/src/shared/components/ScrollableContainer/Container.tsx
@@ -1,0 +1,61 @@
+import { ReactNode } from "react";
+
+import Button, { ButtonTheme } from "shared/components/Button/Container";
+import Announcement from "shared/components/Announcement/Container";
+
+import {
+  Container,
+  ButtonAreaContainer,
+  AnnouncementAreaContainer,
+} from "./Container.style";
+
+interface ScrollableContainerProps {
+  bottomAnnouncement?: {
+    buttonText: string;
+    leftText: string;
+    onButtonClick: () => void;
+    rightText: string;
+  };
+  bottomButtons?: {
+    leftButtonText: string;
+    onLeftButtonClick: () => void;
+    onRightButtonClick: () => void;
+    rightButtonText: string;
+  };
+  className?: string;
+  children: ReactNode;
+}
+
+const ScrollableContainer = (props: ScrollableContainerProps) => {
+  return (
+    <Container className={props.className}>
+      {props.children}
+      {props.bottomButtons && (
+        <ButtonAreaContainer>
+          <Button
+            onButtonClick={props.bottomButtons.onLeftButtonClick}
+            text={props.bottomButtons.leftButtonText}
+            theme={ButtonTheme.LIGHT}
+          />
+          <Button
+            onButtonClick={props.bottomButtons.onRightButtonClick}
+            text={props.bottomButtons.rightButtonText}
+            theme={ButtonTheme.DARK}
+          />
+        </ButtonAreaContainer>
+      )}
+      {props.bottomAnnouncement && (
+        <AnnouncementAreaContainer>
+          <Announcement
+            buttonText={props.bottomAnnouncement.buttonText}
+            leftText={props.bottomAnnouncement.leftText}
+            onButtonClick={props.bottomAnnouncement.onButtonClick}
+            rightText={props.bottomAnnouncement.rightText}
+          />
+        </AnnouncementAreaContainer>
+      )}
+    </Container>
+  );
+};
+
+export default ScrollableContainer;


### PR DESCRIPTION
* [ESC-14] flipdown 라이브러리 설치 & 활용 실패 & 숫자카드 UI 생성

* [ESC-14] main 페이지 UI 리팩토링

* [ESC-14] main 페이지 하단 버튼 영역 sticky 적용

* [ESC-14] join 페이지 하단 안내 영역 sticky 적용

* [ESC-14] login 페이지 하단 안내 영역 sticky 적용 & ScrollableContainer와 sticky 영역 리팩토링

* [ESC-14] findAccount 페이지 하단 안내 영역 sticky 적용

* [ESC-14] flipdown 라이브러리 제거

* [ESC-14] 꿈 작성하기 영역 line-height 설정

* [ESC-14] ContentContainer 네이밍 통일

* [ESC-14] style 적용이 가능하도록 NavigationBar 컴포넌트에 className 적용

* [ESC-14] certificate 페이지에에 scrollableContainer 적용 & 하단 버튼 영역 sticky 적용

* [ESC-14] selectAirplane 페이지 하단 버튼 영역 sticky 적용