### PR TITLE
[ESC-16] UI 자체 QA (#26)

### DIFF
--- a/public/404.html
+++ b/public/404.html
@@ -17,7 +17,7 @@
       crossorigin
       href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.6/dist/web/static/pretendard.css"
     />
-    <title>React App</title>
+    <title>에스칼프린트 온라인 기부</title>
     <!-- Start Single Page Apps for GitHub Pages -->
     <script type="text/javascript">
       // Single Page Apps for GitHub Pages

--- a/public/index.html
+++ b/public/index.html
@@ -17,7 +17,7 @@
       crossorigin
       href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.6/dist/web/static/pretendard.css"
     />
-    <title>React App</title>
+    <title>에스칼프린트 온라인 기부</title>
     <!-- Start Single Page Apps for GitHub Pages -->
     <script type="text/javascript">
       // Single Page Apps for GitHub Pages

--- a/src/features/donationCertificate/Container.style.tsx
+++ b/src/features/donationCertificate/Container.style.tsx
@@ -28,7 +28,7 @@ export const CertificateArea = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
-  margin-bottom: 15rem;
+  margin-bottom: 13.5rem;
   padding: 3.6rem 3.4rem 1.6rem 3.4rem;
   border: 0.2rem solid #36e017;
   border-radius: 2rem;
@@ -61,6 +61,7 @@ export const AirplaneImage = styled.img`
 export const Phrase = styled.p`
   margin-bottom: 0.8rem;
   color: ${colors.gray500};
+  font-size: 1rem;
 `;
 
 export const Signature = styled.div`

--- a/src/features/donationCertificate/hooks/useDonationCertificate.tsx
+++ b/src/features/donationCertificate/hooks/useDonationCertificate.tsx
@@ -14,7 +14,9 @@ const useDonationCertificate = () => {
   const certificateAreaRef = useRef<HTMLDivElement>(null);
   const [nickname, setNickname] = useState("");
 
-  const handleBackToMainClick = () => {};
+  const handleBackToMainClick = () => {
+    navigate("/");
+  };
 
   const handleHistoryClick = () => {
     navigate("/history");

--- a/src/features/donationHistory/Container.style.tsx
+++ b/src/features/donationHistory/Container.style.tsx
@@ -1,8 +1,9 @@
 import styled from "styled-components";
 
+import NavigationBar from "shared/components/NavigationBar/Container";
 import Title from "shared/components/Title/Container";
 import Description from "shared/components/Description/Container";
-import Announcement from "shared/components/Announcement/Container";
+import { AnnouncementAreaContainer } from "shared/components/ScrollableContainer/Container.style";
 
 import colors from "shared/assets/colors";
 
@@ -13,6 +14,9 @@ export const Container = styled.div`
   ::-webkit-scrollbar {
     display: none;
   }
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
   height: 100%;
 `;
 
@@ -21,6 +25,11 @@ export const ContentContainer = styled.div`
   display: flex;
   flex-direction: column;
   padding: 2rem;
+  padding-top: 0rem;
+`;
+
+export const StyledNavigationBar = styled(NavigationBar)`
+  margin-bottom: 2rem;
 `;
 
 export const StyledTitle = styled(Title)`
@@ -89,9 +98,6 @@ export const LoadMoreButton = styled.button`
   color: ${colors.white};
 `;
 
-export const StyledAnnouncement = styled(Announcement)`
-  position: absolute;
-  left: 50%;
-  bottom: 2rem;
-  transform: translateX(-50%);
+export const AnnouncementContainer = styled(AnnouncementAreaContainer)`
+  width: 100%;
 `;

--- a/src/features/donationHistory/Container.tsx
+++ b/src/features/donationHistory/Container.tsx
@@ -1,21 +1,21 @@
 import useDonationHistory from "./hooks/useDonationHistory";
 
-import NavigationBar from "shared/components/NavigationBar/Container";
 import DonationItem from "features/donationHistory/components/DonationItem/Container";
 import Announcement from "shared/components/Announcement/Container";
 
 import {
+  AnnouncementContainer,
   Container,
   ContentContainer,
   DonationList,
   DonationTotal,
   LoadMoreButton,
   StyledDescription,
+  StyledNavigationBar,
   StyledTitle,
   Subtitle,
   SubtitleArea,
 } from "./Container.style";
-import { AnnouncementAreaContainer } from "shared/components/ScrollableContainer/Container.style";
 import dummyData from "./dummyData";
 
 const DonationHistoryContainer = () => {
@@ -23,8 +23,8 @@ const DonationHistoryContainer = () => {
 
   return (
     <Container>
-      <NavigationBar title="나의 꿈 기부내역" />
       <ContentContainer>
+        <StyledNavigationBar title="나의 꿈 기부내역" />
         <StyledTitle
           text={`영원한 꿈 기부천사!
         ${"물에젖은꼬지모"}님 반가워요 :)`}
@@ -48,14 +48,14 @@ const DonationHistoryContainer = () => {
         </DonationList>
         <LoadMoreButton onClick={handleLoadMoreClick}>더보기</LoadMoreButton>
       </ContentContainer>
-      <AnnouncementAreaContainer>
+      <AnnouncementContainer>
         <Announcement
           buttonText="여기"
           leftText="각종 공지사항은 "
           onButtonClick={handleNoticeClick}
           rightText="에서 확인하실 수 있어요!"
         />
-      </AnnouncementAreaContainer>
+      </AnnouncementContainer>
     </Container>
   );
 };

--- a/src/features/findAccount/components/FindIdTabContents/Container.style.tsx
+++ b/src/features/findAccount/components/FindIdTabContents/Container.style.tsx
@@ -29,6 +29,7 @@ export const ResultValue = styled.span`
 export const PsNote = styled.p`
   margin-bottom: 1.2rem;
   color: ${colors.gray500};
+  font-size: 1rem;
 `;
 
 export const StyledButton = styled(Button)`

--- a/src/features/findAccount/components/FindPasswordTabContents/index.style.tsx
+++ b/src/features/findAccount/components/FindPasswordTabContents/index.style.tsx
@@ -29,6 +29,7 @@ export const ResultValue = styled.span`
 export const PsNote = styled.p`
   margin-bottom: 1.2rem;
   color: ${colors.gray500};
+  font-size: 1rem;
 `;
 
 export const StyledButton = styled(Button)`

--- a/src/features/main/Components/NoticeSection/Container.style.tsx
+++ b/src/features/main/Components/NoticeSection/Container.style.tsx
@@ -5,13 +5,18 @@ export const Container = styled.ul`
   width: 100%;
 
   > li {
+    color: ${colors.gray500};
+    font-size: 1rem;
     line-height: 1.8rem;
 
     > span {
+      color: ${colors.gray800};
+      font-size: 1rem;
       font-weight: 600;
     }
 
     > button {
+      font-size: 1rem;
       color: ${colors.green500};
       font-weight: 600;
       text-decoration: underline;

--- a/src/features/selectAirplane/Container.style.tsx
+++ b/src/features/selectAirplane/Container.style.tsx
@@ -1,8 +1,5 @@
 import styled from "styled-components";
 
-import Title from "shared/components/Title/Container";
-import Description from "shared/components/Description/Container";
-
 import colors from "shared/assets/colors";
 
 export const Container = styled.div`
@@ -14,24 +11,24 @@ export const Container = styled.div`
   }
   display: flex;
   flex-direction: column;
-  justify-content: space-between;
   height: 100%;
   background-color: ${colors.white};
 `;
 
 export const ContentContainer = styled.div<{ backgroundColor: string }>`
+  flex-grow: 1;
   display: flex;
   flex-direction: column;
+  justify-content: space-between;
   width: 100%;
   padding: 2.5rem 2rem 0rem 2rem;
   background-image: ${({ backgroundColor }) => backgroundColor};
 `;
 
-export const StyledTitle = styled(Title)`
-  margin-bottom: 1.2rem;
-`;
-
-export const StyledDescription = styled(Description)`
+export const TitleArea = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
   margin-bottom: 3.6rem;
 `;
 
@@ -56,11 +53,9 @@ export const AirplanePreview = styled.div<{
 `;
 
 export const WhiteBoard = styled.div`
-  flex-grow: 1;
   display: flex;
   flex-direction: column;
   width: calc(100% + 4rem);
-  height: 10rem;
   margin-left: -2rem;
   padding: 2rem;
   padding-top: 2.6rem;

--- a/src/features/selectAirplane/Container.tsx
+++ b/src/features/selectAirplane/Container.tsx
@@ -1,19 +1,20 @@
 import useSelectAirplane from "./hooks/useSelectAirplane";
 
-import Button, { ButtonTheme } from "shared/components/Button/Container";
-import AirplaneSlider from "./components/AirplaneSlider/Container";
-
 import airplaneList from "./constants/airplaneList";
+
+import Title from "shared/components/Title/Container";
+import Description from "shared/components/Description/Container";
+import AirplaneSlider from "./components/AirplaneSlider/Container";
+import Button, { ButtonTheme } from "shared/components/Button/Container";
 
 import {
   AirplanePreview,
-  BoardTitle,
   ButtonContainer,
+  BoardTitle,
   Container,
   ContentContainer,
   Division,
-  StyledTitle,
-  StyledDescription,
+  TitleArea,
   WhiteBoard,
 } from "./Container.style";
 
@@ -28,8 +29,10 @@ const SelectAirplaneContainer = () => {
   return (
     <Container>
       <ContentContainer backgroundColor={selectedAirplane.containerBackground}>
-        <StyledTitle text="종이비행기를 선택해주세요!" />
-        <StyledDescription text="내가 선택한 종이비행기에 꿈을 적을 수 있어요 :)" />
+        <TitleArea>
+          <Title text="종이비행기를 선택해주세요!" />
+          <Description text="내가 선택한 종이비행기에 꿈을 적을 수 있어요 :)" />
+        </TitleArea>
         <AirplanePreview borderColor={selectedAirplane.previewBorder}>
           <img
             src={selectedAirplane.image}

--- a/src/shared/components/Input/Container.style.tsx
+++ b/src/shared/components/Input/Container.style.tsx
@@ -35,4 +35,5 @@ export const InputField = styled.input<{ wrongInput: boolean }>`
 
 export const WarningMessage = styled.p`
   color: ${colors.red};
+  font-size: 1rem;
 `;


### PR DESCRIPTION
* [ESC-16] 홈으로 이동하기 클릭시 navigate 되도록 추가

* [ESC-16] 인증서 하단 margin 수정

* [ESC-16] 기부내역 하단 안내문구 width 조정

* [ESC-16] 기부내역이 짧아질때를 대비해 justify-contents: space-between 적용

* [ESC-16] selectAirplane의 height가 짧을때 scroll을 하면 하단 버튼영역의 아래에 여백이 생기는 이슈
- whiteBoard 영역의 height가 고정되어있어 발생하는 문제
- height 고정값을 제거함
- 그리고 해당 페이지의 전체적인 간격이 height에 유동적으로 대응할 수 있도록 Container 수정 및 TitleArea 추가

* [ESC-16] font-size: 1rem 추가

* [ESC-16] 메인 페이지 공지사항 color 정정

* [ESC-16] html title 변경

* [ESC-16] 인증서 문구 font-size 추가