### PR TITLE
[ESC-22] 프론트 자체 QA (#40)

### DIFF
--- a/src/features/App/apis/getAutoLoginAvailable.ts
+++ b/src/features/App/apis/getAutoLoginAvailable.ts
@@ -18,7 +18,7 @@ const getAutoLoginAvailable = async () => {
 
     return {
       result: true,
-      data: res.data as { isLogin: boolean; nickname: string },
+      data: res.data as { nickname: string },
     };
   } catch (e) {
     const error = e as AxiosError;

--- a/src/features/App/hooks/useApp.ts
+++ b/src/features/App/hooks/useApp.ts
@@ -18,17 +18,22 @@ const useApp = () => {
   }, []);
 
   const checkAutoLoginAvailable = async () => {
+    const accessToken = localStorage.getItem("accessToken");
+
+    if (!accessToken) {
+      return;
+    }
+
     const { result, data } = await getAutoLoginAvailable();
 
     if (!result || !data) {
-      // TODO: accessToken이 없을 경우에는 toast가 나오지 않도록
       showToast(`에러가 발생했어요.
       이 메시지가 반복된다면 1688-4272 고객센터로 연락주세요.`);
       return;
     }
 
-    if (data.isLogin) {
-      setNickname(data.nickname || ""); // TODO: 기본값 없애야
+    if (data.nickname) {
+      setNickname(data.nickname);
       return;
     } else {
       localStorage.removeItem("accessToken");
@@ -37,6 +42,12 @@ const useApp = () => {
   };
 
   const checkParticipated = async () => {
+    const accessToken = localStorage.getItem("accessToken");
+
+    if (!accessToken) {
+      return;
+    }
+
     const { result, data } = await getParticipation();
 
     if (result && data) {

--- a/src/features/donationCertificate/constants/certificateColorList.ts
+++ b/src/features/donationCertificate/constants/certificateColorList.ts
@@ -24,7 +24,7 @@ const certificateColorList: CertificateColor[] = [
     key: AirplaneColor.SKY,
     pageBackgroundImage: "linear-gradient(205deg, #77d6eb, #2bacc9)",
     borderColor: "#31d8ff",
-    certificateBackgroundImage: "linear-gradient(to bottom, ##f1ffff, #d3fbfe)",
+    certificateBackgroundImage: "linear-gradient(to bottom, #f1ffff, #d3fbfe)",
   },
   {
     key: AirplaneColor.PINK,

--- a/src/features/donationHistory/detail/hooks/useDonationHistoryDetail.ts
+++ b/src/features/donationHistory/detail/hooks/useDonationHistoryDetail.ts
@@ -1,17 +1,25 @@
+import { useContext } from "react";
 import { useLocation } from "react-router-dom";
 import useSWR from "swr";
 
 import getDonationDetail from "../apis/getDonationDetail";
+import { ToastContext } from "shared/components/Toast/ToastProvider";
 
 const useDonationHistoryDetail = () => {
   const location = useLocation();
   const donationId = location.pathname.split("/")[2];
+  const { showToast } = useContext(ToastContext);
 
   const { data } = useSWR(
     `/mypage/airplane/${donationId}`,
     (key) => getDonationDetail(key, donationId),
     { revalidateIfStale: false, revalidateOnFocus: false }
   );
+
+  if (!data) {
+    showToast(`에러가 발생했어요.
+    이 메시지가 반복된다면 1688-4272 고객센터로 연락주세요.`);
+  }
 
   return { donationDetail: data ? data.data : undefined };
 };

--- a/src/features/login/apis/getPasswordExist.ts
+++ b/src/features/login/apis/getPasswordExist.ts
@@ -1,0 +1,26 @@
+import axios, { AxiosError } from "axios";
+
+interface GetPasswordExistProps {
+  password: string;
+}
+
+const getPasswordExist = async (props: GetPasswordExistProps) => {
+  try {
+    const API_URI = process.env.REACT_APP_API_URI;
+    const res = await axios.get(
+      `${API_URI}/account/password/${props.password}`,
+      {
+        headers: { "Content-Type": "application/json" },
+      }
+    );
+
+    return { result: true, data: res.data as { isExist: boolean } };
+  } catch (e) {
+    const error = e as AxiosError;
+    const statusCode = error.response?.status;
+
+    return { result: false, statusCode };
+  }
+};
+
+export default getPasswordExist;

--- a/src/features/login/hooks/useLogin.ts
+++ b/src/features/login/hooks/useLogin.ts
@@ -19,7 +19,7 @@ const useLogin = () => {
   const { handleAccountIdChange, accountId, accountIdWarningMessage } =
     useAccountIdInput();
   const { handlePasswordChange, password, passwordWarningMessage } =
-    usePasswordInput({ accountId });
+    usePasswordInput();
 
   const handleJoinClick = () => {
     navigate("/join");

--- a/src/features/login/hooks/usePasswordInput.ts
+++ b/src/features/login/hooks/usePasswordInput.ts
@@ -3,13 +3,9 @@ import { ChangeEvent, useContext, useState } from "react";
 import useDebouncedCallback from "shared/utils/useDebouncedCallback";
 import { ToastContext } from "shared/components/Toast/ToastProvider";
 
-import postSignIn from "../apis/postSignIn";
+import getPasswordExist from "../apis/getPasswordExist";
 
-interface UsePasswordInputProps {
-  accountId: string;
-}
-
-const usePasswordInput = (props: UsePasswordInputProps) => {
+const usePasswordInput = () => {
   const { showToast } = useContext(ToastContext);
   const [password, setPassword] = useState("");
   const [passwordWarningMessage, setPasswordWarningMessage] = useState("");
@@ -19,32 +15,31 @@ const usePasswordInput = (props: UsePasswordInputProps) => {
     setPassword(inputValue);
 
     if (inputValue.length > 0) {
-      debouncedCheckLoginPossible(inputValue);
+      debouncedCheckPasswordExist(inputValue);
     }
   };
 
-  const checkLoginPossible = async (inputValue: string) => {
-    const { result, data, statusCode } = await postSignIn({
-      accountId: props.accountId,
+  const checkPasswordExist = async (inputValue: string) => {
+    const { result, data } = await getPasswordExist({
       password: inputValue,
     });
 
-    if (result && data) {
+    if (!result || !data) {
+      showToast(`이용량 급증으로 인해 로그인정보 확인이 지연되고 있어요.
+      이 메시지가 반복된다면 1688-4272 고객센터로 연락주세요.`);
+      return;
+    }
+
+    if (data.isExist) {
       setPasswordWarningMessage("");
       return;
-    }
-
-    if (statusCode === 400) {
+    } else {
       setPasswordWarningMessage("이 비밀번호가 아닌거 같아요 :(");
-      return;
     }
-
-    showToast(`이용량 급증으로 인해 로그인정보 확인이 지연되고 있어요.
-    이 메시지가 반복된다면 1688-4272 고객센터로 연락주세요.`);
   };
 
-  const debouncedCheckLoginPossible = useDebouncedCallback(
-    checkLoginPossible,
+  const debouncedCheckPasswordExist = useDebouncedCallback(
+    checkPasswordExist,
     225
   );
 

--- a/src/features/main/Container.tsx
+++ b/src/features/main/Container.tsx
@@ -1,3 +1,6 @@
+import { useAtom } from "jotai";
+
+import nicknameAtom from "shared/atoms/nicknameAtom";
 import useMain from "./hooks/useMain";
 
 import ScrollableContainer from "shared/components/ScrollableContainer/Container";
@@ -14,8 +17,8 @@ import {
 import holdPaperAirplane from "shared/assets/imgs/holdPaperAirplane.png";
 
 const MainContainer = () => {
+  const [nickname] = useAtom(nicknameAtom);
   const {
-    loginStatus,
     handleNoticeClick,
     handleShareClick,
     handleJoinClick,
@@ -28,7 +31,7 @@ const MainContainer = () => {
   return (
     <ScrollableContainer
       bottomButtons={
-        loginStatus
+        nickname
           ? {
               leftButtonText: "내 꿈 기부내역 보기",
               onLeftButtonClick: handleHistoryClick,

--- a/src/features/main/hooks/useMain.ts
+++ b/src/features/main/hooks/useMain.ts
@@ -18,7 +18,6 @@ const useMain = () => {
   const [participated] = useAtom(participatedAtom);
   const [totalAirplaneCount, setTotalAirplaneCount] = useState(0);
   const [totalDonation, setTotalDonation] = useState(0);
-  const [loginStatus, setLoginStatus] = useState(false);
 
   useEffect(() => {
     initDonationSummary();
@@ -121,8 +120,28 @@ const useMain = () => {
   };
 
   const handleJoinClick = () => {
-    if (checkDonationAvailability()) {
+    const today = new Date(2023, 3, 15); // TODO: 나중에 빈값으로 수정해줘야함
+    const eventStartDate = new Date(2023, 3, 10);
+    const timeDifference = eventStartDate.getTime() - today.getTime();
+
+    if (timeDifference > 0) {
+      const seconds = timeDifference / 1000;
+      const minutes = seconds / 60;
+      const hours = minutes / 60;
+      const days = Math.floor(hours / 24);
+
+      const remainingHours = Math.floor(hours % 24);
+      const remainingMinutes = Math.floor(minutes % 60);
+
+      showToast(
+        `아직 서비스를 준비하고 있어요!
+        ${days}일 ${remainingHours}시간 ${remainingMinutes}분 뒤에 만나기로 해요!`,
+        ToastTheme.GRAY
+      );
+      return;
+    } else {
       navigate("/join");
+      return;
     }
   };
 
@@ -131,10 +150,12 @@ const useMain = () => {
   };
 
   const handleDonateClick = () => {
-    navigate("/selectairplane");
+    if (checkDonationAvailability()) {
+      navigate("/selectairplane");
+    }
   };
+
   return {
-    loginStatus,
     handleNoticeClick,
     handleShareClick,
     handleJoinClick,

--- a/src/features/writeDream/Container.style.tsx
+++ b/src/features/writeDream/Container.style.tsx
@@ -47,6 +47,7 @@ export const WritingText = styled.textarea`
   }
   width: 100%;
   height: 100%;
+  margin-bottom: 2rem;
   caret-color: #55ad1e;
   color: ${colors.gray700};
   font-size: 1.8rem;
@@ -60,9 +61,7 @@ export const WritingText = styled.textarea`
 `;
 
 export const LetterCounter = styled.p<{ overwritten: boolean }>`
-  position: absolute;
-  right: 0;
-  bottom: 0;
+  align-self: end;
   color: #c7c7c7;
   font-size: 1.4rem;
 

--- a/src/features/writeDream/Container.tsx
+++ b/src/features/writeDream/Container.tsx
@@ -31,10 +31,10 @@ const WriteDreamContainer = () => {
           onChange={handleTextChange}
           wrap="soft"
         />
-        <LetterCounter overwritten={dream.length > 300}>
-          <span>{dream.length}</span>/300
-        </LetterCounter>
       </WritingArea>
+      <LetterCounter overwritten={dream.length > 300}>
+        <span>{dream.length}</span>/300
+      </LetterCounter>
     </Container>
   );
 };


### PR DESCRIPTION
* [ESC-22] 로그인 가능여부 확인 api의 reponse 값 수정

* [ESC-22] 앱 시작과 동시에 자동로그인가능여부나 참여여부를 확인할때 accessToken이 없는 경우라면 아무것도 실행시키지 않도록 수정

* [ESC-22] 기부상세를 불러오지 못하면 에러 toast를 노출시키도록 수정

* [ESC-22] 로그인 할때에 비밀번호 존재여부 확인 api 연결

* [ESC-22] 로그인 여부에 따라 main 화면 버튼 다르게 노출

* [ESC-22] 기부작성화면의 작성영역과 글자수영역 분리

* [ESC-22] 비밀번호 존재여부 확인결과 처리로직 수정

* [ESC-22] 일자와 유저 상태에 따라 main 화면에 toast 노출하는 조건 설정