### PR TITLE
[ESC-28] 전체 QA 1차 (#61)

### DIFF
--- a/src/features/donationCertificate/Container.style.tsx
+++ b/src/features/donationCertificate/Container.style.tsx
@@ -27,7 +27,7 @@ export const ContentContainer = styled.div<{
   display: flex;
   flex-direction: column;
   align-items: center;
-  width: 100%;
+  width: calc(100% + 4rem);
   background-image: ${({ pageBackgroundImage }) => pageBackgroundImage};
 `;
 

--- a/src/features/donationCertificate/Container.tsx
+++ b/src/features/donationCertificate/Container.tsx
@@ -51,7 +51,8 @@ const DonationCertificateContainer = () => {
         >
           <Title>
             {nickname.length > 0
-              ? `${nickname}님! 기부에 동참해주셔서 감사해요 :)`
+              ? `${nickname}님!
+              기부에 동참해주셔서 감사해요 :)`
               : `기부에 동참해주셔서 감사해요 :)`}
           </Title>
           <Description>{`꿈이 이루어질 수 있도록 에스칼프린트가 함께할게요!

--- a/src/features/donationCertificate/hooks/useDonationCertificate.tsx
+++ b/src/features/donationCertificate/hooks/useDonationCertificate.tsx
@@ -95,7 +95,10 @@ const useDonationCertificate = () => {
     certificateColorList.find((item) => item.key === airplaneColor) ||
     certificateColorList[0];
 
-  const airplaneImage = state?.airplaneImage || airplaneList[0].certificate;
+  const airplaneImage =
+    airplaneList.find((airplane) => airplane.key === airplaneColor)
+      ?.certificate || airplaneList[0].certificate;
+  // const airplaneImage = state?.airplaneImage || airplaneList[0].certificate;
 
   return {
     airplaneImage,

--- a/src/features/donationHistory/apis/useDonationHistoryData.ts
+++ b/src/features/donationHistory/apis/useDonationHistoryData.ts
@@ -61,7 +61,7 @@ const useDonationHistoryData = () => {
   const { data, size, setSize } = useSWRInfinite(getKey, fetcher, {
     revalidateAll: false,
     revalidateFirstPage: false,
-    revalidateIfStale: false,
+    // revalidateIfStale: false,
     revalidateOnFocus: false,
   });
 

--- a/src/features/donationHistory/detail/apis/getDonationDetail.ts
+++ b/src/features/donationHistory/detail/apis/getDonationDetail.ts
@@ -14,7 +14,6 @@ const getDonationDetail = async (key: string, donationId?: string) => {
   const API_URI = process.env.REACT_APP_API_URI;
   const accessToken = localStorage.getItem("escalAccessToken");
 
-  console.log("accessToken ,donationId", accessToken, donationId);
   if (!accessToken || !donationId) {
     return undefined;
   }

--- a/src/features/donationHistory/detail/hooks/useDonationHistoryDetail.ts
+++ b/src/features/donationHistory/detail/hooks/useDonationHistoryDetail.ts
@@ -10,13 +10,13 @@ const useDonationHistoryDetail = () => {
   const donationId = location.pathname.split("/")[2];
   const { showToast } = useContext(ToastContext);
 
-  const { data } = useSWR(
+  const { data, isLoading } = useSWR(
     `/mypage/airplane/${donationId}`,
     (key) => getDonationDetail(key, donationId),
     { revalidateIfStale: false, revalidateOnFocus: false }
   );
 
-  if (!data) {
+  if (!isLoading && !data) {
     showToast(`에러가 발생했어요.
     이 메시지가 반복된다면 1688-4272 고객센터로 연락주세요.`);
   }

--- a/src/features/join/hooks/useJoin.ts
+++ b/src/features/join/hooks/useJoin.ts
@@ -62,8 +62,6 @@ const useJoin = () => {
       password,
     });
 
-    // console.log("accountId", accountId, "password", password, "data", data);
-
     if (result && data) {
       localStorage.setItem("escalAccessToken", data.accessToken);
       setNickname(data.nickname);

--- a/src/features/writeDream/hooks/useWriteDream.ts
+++ b/src/features/writeDream/hooks/useWriteDream.ts
@@ -57,7 +57,7 @@ const useWriteDream = () => {
       navigate("/certificate", {
         state: {
           airplaneColor,
-          airplaneImage: imageUrl,
+          // airplaneImage: imageUrl,
         },
       });
     } else {


### PR DESCRIPTION
* [ESC-28] 기부상세 접근 하자마자 에러 토스트가 뜸

* [ESC-28] 인증서 타이틀 줄바꿈 추가

* [ESC-28] 인증서 저장시 좌우 여백 추가

* [ESC-28] 기부내역 데이터 revalidate 옵션 수정: key가 accessToken에 의존하지 않기 때문에 revalidate될 조건이 필요함

* [ESC-28] 이미지 저장/공유 시에 종이비행기 이미지가 포함되지 못하는 이슈: 임시로 저장된 파일 그대로 사용하는것으로 처리함